### PR TITLE
New config option that when enabled will send mqtt states as json objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ mqttport = <mqtt port>
 username = <mqtt username> (Optional)
 password = <mqtt password> (Optional)
 topic = <topic, e.g. home/livingroom/music>
+json_state = false (mqtt state will be a json struct instead of a string)
 ```
 
 Restart Mopidy with `sudo service mopidy restart`

--- a/mopidy_mqtt/__init__.py
+++ b/mopidy_mqtt/__init__.py
@@ -27,6 +27,7 @@ class Extension(ext.Extension):
         schema['mqttport'] = config.Integer()
         schema['username'] = config.String()
         schema['password'] = config.String()
+        schema['json_state'] = config.Boolean()
         return schema
 
     def setup(self, registry):

--- a/mopidy_mqtt/ext.conf
+++ b/mopidy_mqtt/ext.conf
@@ -5,3 +5,4 @@ mqttport = 1883
 topic = home/livingroom/music
 username = username
 password = password
+json_state = False


### PR DESCRIPTION
This allows for the data to be parsed on the other end and for more information to be sent to the subscribers. 

If left off it's not breaking.

Examples of changes with this enabled

**New**
{"artist": "Ocean 100 (Charlottetown, Canada)", "title": "Mony Mony - Billy Idol"}
**Old**
The Beatles:Here Comes The Sun - Remastered

**New**
{"title": "NF - Let You Down"}
**Old**
Chris Brown - Questions

**New**
{"old_state": "playing", "new_state": "playing"}
**Old**
playing